### PR TITLE
Events and other fixes

### DIFF
--- a/Assets/Materials/ForestGround.mat
+++ b/Assets/Materials/ForestGround.mat
@@ -65,12 +65,12 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.034
+    - _Glossiness: 0.129
     - _GlossyReflections: 1
-    - _Metallic: 0
+    - _Metallic: 0.388
     - _Mode: 0
     - _OcclusionStrength: 1
-    - _Parallax: 0.0519
+    - _Parallax: 0.0438
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1

--- a/Assets/Prefabs/Enemys/Blob.prefab
+++ b/Assets/Prefabs/Enemys/Blob.prefab
@@ -111,8 +111,8 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7605445102627406323}
   serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
+  m_Mass: 10
+  m_Drag: 20
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
@@ -144,7 +144,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _player: {fileID: 0}
-  _forceModifier: 0.2
+  speed: 4
 --- !u!114 &-7070458394552058843
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -158,6 +158,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _type: 0
+  _dmg: 20
+  _hitcdtimer: 0.5
+  _score: 10
 --- !u!114 &8679154005757595980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -175,3 +178,4 @@ MonoBehaviour:
   currentShield: 0
   maxShield: 0
   isInvulnerable: 0
+  isPlayer: 0

--- a/Assets/Prefabs/Enemys/Skelly.prefab
+++ b/Assets/Prefabs/Enemys/Skelly.prefab
@@ -111,8 +111,8 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7605445102627406323}
   serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
+  m_Mass: 20
+  m_Drag: 20
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
@@ -144,7 +144,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _player: {fileID: 0}
-  _forceModifier: 0.3
+  speed: 4
 --- !u!114 &-8024593288149662746
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -158,6 +158,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _type: 1
+  _dmg: 30
+  _hitcdtimer: 0.5
+  _score: 20
 --- !u!114 &2623196749504330094
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -175,3 +178,4 @@ MonoBehaviour:
   currentShield: 0
   maxShield: 0
   isInvulnerable: 0
+  isPlayer: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -411,8 +411,20 @@ PrefabInstance:
       value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.1591
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.1591
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.1591
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -60.9
       objectReference: {fileID: 0}
     - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
       propertyPath: m_LocalPosition.y
@@ -420,7 +432,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 195.6
       objectReference: {fileID: 0}
     - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
       propertyPath: m_LocalRotation.w
@@ -449,6 +461,26 @@ PrefabInstance:
     - target: {fileID: 4063552230360950, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 136275810615880682, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_Radius
+      value: 0.92220503
+      objectReference: {fileID: 0}
+    - target: {fileID: 136275810615880682, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 136275810615880682, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_Center.x
+      value: -0.01014981
+      objectReference: {fileID: 0}
+    - target: {fileID: 136275810615880682, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_Center.y
+      value: 0.99000007
+      objectReference: {fileID: 0}
+    - target: {fileID: 136275810615880682, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
+      propertyPath: m_Center.z
+      value: -0.028204603
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dbf7a0c9d76b77a40af3104feac0641d, type: 3}
@@ -604,6 +636,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: EnemySpawn (8)
       objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
 --- !u!1 &504193650 stripped
@@ -646,8 +682,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   child: {fileID: 504193650}
   speed: 30
-  spellType: 0
+  spellType: 1
   spellsPool: {fileID: 2065999544}
+  spellcd: 1
 --- !u!114 &504193660
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -664,7 +701,8 @@ MonoBehaviour:
   maxHealth: 150
   currentShield: 0
   maxShield: 0
-  isInvulnerable: 0
+  isInvulnerable: 1
+  isPlayer: 1
 --- !u!1 &557727966
 GameObject:
   m_ObjectHideFlags: 0
@@ -961,6 +999,10 @@ PrefabInstance:
     - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
       propertyPath: m_Name
       value: EnemySpawn (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
@@ -1268,6 +1310,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: EnemySpawn
       objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
 --- !u!1 &771567232
@@ -1405,6 +1451,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: EnemySpawn (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
 --- !u!1001 &921289453
@@ -1461,6 +1511,10 @@ PrefabInstance:
     - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
       propertyPath: m_Name
       value: EnemySpawn (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
@@ -1991,6 +2045,10 @@ PrefabInstance:
     - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
       propertyPath: m_Name
       value: EnemySpawn (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
@@ -2570,6 +2628,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: EnemySpawn (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
 --- !u!1001 &1562326738
@@ -2626,6 +2688,10 @@ PrefabInstance:
     - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
       propertyPath: m_Name
       value: EnemySpawn (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
@@ -2684,6 +2750,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: EnemySpawn (7)
       objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
 --- !u!1001 &1708412520
@@ -2740,6 +2810,10 @@ PrefabInstance:
     - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
       propertyPath: m_Name
       value: EnemySpawn (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3566547586403773215, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3785819d77bd00f4c81cca92cd2b363a, type: 3}

--- a/Assets/ScripteableObjects/Waves/FirstWave-TestWave.asset
+++ b/Assets/ScripteableObjects/Waves/FirstWave-TestWave.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f1f811c759a59647bb82d2025c6270d, type: 3}
   m_Name: FirstWave-TestWave
   m_EditorClassIdentifier: 
-  MaxBlobOnWave: 20
+  MaxBlobOnWave: 10
   MaxSkellyOnWave: 10
   MaxBlobOnScreen: 10
   MaxSkellyOnScreen: 5

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -7,15 +7,22 @@ using UnityEngine;
 /// </summary>
 public class Enemy : MonoBehaviour
 {
-    [SerializeField]
-    private EnemyType _type;
+    [SerializeField] private EnemyType _type;
+    [SerializeField] private float _dmg;
+    [SerializeField] private float _hitcdtimer;
+    [SerializeField] private int _score;
+    
     private string _insult;
-    private int healthPoints;
     private int maxHealthPoints;
+    private int healthPoints;
     private Vector3 _orignalSpawnPoint;
-
+    private float _hitcd;
+    
     public EnemyType Type { get => _type; set => _type = value; }
-
+    public float Dmg { get => _dmg; set => _dmg = value; }
+    public float Hitcdtimer { get => _hitcdtimer; set => _hitcdtimer = value; }
+    public int Score { get => _score; set => _score = value; }
+    
     public void InitializeSelf()
     {
         gameObject.SetActive(false);
@@ -37,7 +44,7 @@ public class Enemy : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+        _hitcd = (_hitcd < 0)? 0 : _hitcd-=Time.deltaTime;
     }
 
     public void OnDeath()
@@ -46,6 +53,21 @@ public class Enemy : MonoBehaviour
         //initialize itself?
         //Send a message about death
         InitializeSelf();
+    }
+    
+    
+    private void OnCollisionStay(Collision collision)
+    {
+        
+        //TODO: send messages or something, the collision with player should be handled by the player, probably?
+        if (collision.gameObject.CompareTag("Player") && _hitcd<=0)
+        {
+            collision.gameObject.GetComponent<HealthSystem>().TakeDamage(Dmg, TypeOfSpellElement.Physical);
+            _hitcd = _hitcdtimer;
+        }
+        
+        if (collision.gameObject.CompareTag("Enemy"))
+            Debug.Log("Im terribly sorry :(");
     }
 }
 public enum EnemyType

--- a/Assets/Scripts/Enemy/EnemyCollision.cs
+++ b/Assets/Scripts/Enemy/EnemyCollision.cs
@@ -19,12 +19,5 @@ public class EnemyCollision : MonoBehaviour
         
     }
 
-    private void OnCollisionEnter(Collision collision)
-    {
-        //TODO: send messages or something, the collision with player should be handled by the player, probably?
-        if (collision.gameObject.CompareTag("Player"))
-            Debug.Log("DIE SCUM!");
-        if (collision.gameObject.CompareTag("Enemy"))
-            Debug.Log("Im terribly sorry :(");
-    }
+
 }

--- a/Assets/Scripts/Enemy/EnemyMovement.cs
+++ b/Assets/Scripts/Enemy/EnemyMovement.cs
@@ -12,10 +12,10 @@ public class EnemyMovement : MonoBehaviour
     [SerializeField]
     private GameObject _player;
     [SerializeField]
-    private float _forceModifier;
+    private float speed;
 
     public GameObject Player { get => _player; set => _player = value; }
-    public float ForceModifier { get => _forceModifier; set => _forceModifier = value; }
+    public float ForceModifier { get => speed; set => speed = value; }
 
     void Start()
     {
@@ -41,6 +41,12 @@ public class EnemyMovement : MonoBehaviour
     {
         //TODO: Adjust this to make it more "playable"
         Vector3 finalDirection =  Player.transform.position - gameObject.transform.position;
-        _rigidbody.AddForce(Vector3.Normalize(finalDirection) * _forceModifier, ForceMode.VelocityChange);
+        finalDirection = Vector3.Normalize(finalDirection);
+
+        _rigidbody.AddForce(finalDirection * speed, ForceMode.VelocityChange);
+
+
     }
 }
+
+

--- a/Assets/Scripts/Enemy/EnemyPool.cs
+++ b/Assets/Scripts/Enemy/EnemyPool.cs
@@ -11,6 +11,16 @@ public class EnemyPool
     private static EnemyPool instance;
     private Dictionary<EnemyType, BasicPooling> enemyPool;
     // Start is called before the first frame update
+    
+    void OnEnable()
+    {
+        EventManager.OnEnemyDeath += StartReturnEnemyToPool;
+    }
+        
+    void OnDisable()
+    {
+        EventManager.OnEnemyDeath -= StartReturnEnemyToPool;
+    }
    
     private EnemyPool()
     {
@@ -62,12 +72,11 @@ public class EnemyPool
     /// Returns the enemy to it's pool
     /// </summary>
     /// <param name="enemyInstance">The enemy that just died</param>
-    void OnEnemyDeath(GameObject enemyInstance)
+    public void StartReturnEnemyToPool(Enemy enemy)
     {
-        Enemy enemy = enemyInstance.GetComponent<Enemy>();
         if(enemy != null)
         {
-            ReturnEnemyToPool(enemy.Type, enemyInstance);
+            ReturnEnemyToPool(enemy.Type, enemy.gameObject);
         }
     }
 }

--- a/Assets/Scripts/Enemy/EnemySpawn.cs
+++ b/Assets/Scripts/Enemy/EnemySpawn.cs
@@ -24,18 +24,16 @@ public class EnemySpawn : MonoBehaviour
 
     private List<EnemyType> enemyTypesToSpawn;
 
-    // Start is called before the first frame update
-    void Start()
+    void OnEnable()
     {
-       
+        EventManager.OnPlayerDeath += StopSpawn;
     }
-
-    // Update is called once per frame
-    void Update()
-    {
         
+    void OnDisable()
+    {
+        EventManager.OnPlayerDeath -= StopSpawn;
     }
-
+    
     private void SpawnEnemy()
     {
         //We could optimize this if we know how many enemies are currently deployed
@@ -109,7 +107,7 @@ public class EnemySpawn : MonoBehaviour
     /// <summary>
     /// When the player dies, we stop spawning enemies
     /// </summary>
-    public void OnPlayerDeath()
+    public void StopSpawn()
     {
         StopCoroutine(RespawnEnemys());
     }

--- a/Assets/Scripts/EventManager.cs
+++ b/Assets/Scripts/EventManager.cs
@@ -41,9 +41,23 @@ public static class EventManager
     public delegate void _OnUpdateScoreUI(int score);
     public static event _OnUpdateScoreUI OnUpdateScoreUI;
 
+    public delegate void _OnPlayerDeath();
+    public static event _OnPlayerDeath OnPlayerDeath;
+    
+    public delegate void _OnEnemyDeath(Enemy enemy);
+    public static event _OnEnemyDeath OnEnemyDeath;
     public static void UpdatePlayerLifeUI(float currentHealth, float maxHealth) => OnUpdatePlayerLifeUI?.Invoke(currentHealth, maxHealth);
     public static void UpdateWaveUI(int currentWave, int currentEnemys, int maxEnemys) => OnUpdateWaveUI?.Invoke(currentWave, currentEnemys, maxEnemys);
     public static void UpdateScoreUI(int score) => OnUpdateScoreUI?.Invoke(score);
+    public static void TriggerOnPlayerDeath() => OnPlayerDeath?.Invoke();
+
+    public static void TriggerOnEnemyDeath(GameObject enemy)
+    {
+        Enemy enemykilled = enemy.GetComponent<Enemy>();
+        
+        OnEnemyDeath?.Invoke(enemykilled);
+        UpdateScoreUI(enemykilled.Score);
+    }
     // ================================ UI Sector ================================
 
 }

--- a/Assets/Scripts/GameScripts/GameController.cs
+++ b/Assets/Scripts/GameScripts/GameController.cs
@@ -18,7 +18,16 @@ public class GameController : MonoBehaviour
     [SerializeField]
     private int currentWave;
 
-    // Start is called before the first frame update
+    void OnEnable()
+    {
+        EventManager.OnPlayerDeath += StopPrepareWave;
+    }
+        
+    void OnDisable()
+    {
+        EventManager.OnPlayerDeath -= StopPrepareWave;
+    }
+    
     void Start()
     {
         GameStart();
@@ -35,12 +44,6 @@ public class GameController : MonoBehaviour
         WaveControl.AllSpawnPoints = AllSpawnPoints;
         WaveControl.enabled = false;
         StartCoroutine(PrepareWave());
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
     }
 
     IEnumerable WavesCoroutine()
@@ -92,7 +95,7 @@ public class GameController : MonoBehaviour
     /// This function should decide what to do when the player dies
     /// Should we start over? just re-start the current wave?
     /// </summary>
-    public void OnPlayerDeath()
+    public void StopPrepareWave()
     {
         StopCoroutine(PrepareWave()); //Not completly sure if this courutine is still going,
                                       //it should't, but, just to sure, we kill it

--- a/Assets/Scripts/GameScripts/WaveController.cs
+++ b/Assets/Scripts/GameScripts/WaveController.cs
@@ -20,6 +20,17 @@ public class WaveController : MonoBehaviour
     public WaveSO Wave { get => _wave; set => _wave = value; }
     private List<GameObject> ActiveSpawnPoints { get => _activeSpawnPoints; set => _activeSpawnPoints = value; }
     public List<GameObject> AllSpawnPoints { get => _allSpawnPoints; set => _allSpawnPoints = value; }
+    
+    void OnEnable()
+    {
+        EventManager.OnEnemyDeath += ReduceEnemy;
+    }
+        
+    void OnDisable()
+    {
+        EventManager.OnEnemyDeath -= ReduceEnemy;
+    }
+
 
     // Start is called before the first frame update
     void Start()
@@ -34,6 +45,9 @@ public class WaveController : MonoBehaviour
         {
             EndWave();
         }
+
+        EventManager.UpdateWaveUI(_wave.WaveNumber, currentEnemiesOnWave.Count,
+            _wave.MaxBlobOnWave + _wave.MaxSkellyOnWave);
     }
     private void LoadSpawnpoints()
     {
@@ -124,9 +138,8 @@ public class WaveController : MonoBehaviour
         }
     }
 
-    void OnEnemyDeath(GameObject enemyInstance)
+    private void ReduceEnemy(Enemy enemy)
     {
-        Enemy enemy = enemyInstance.GetComponent<Enemy>();
         if(currentEnemiesOnWave != null && currentEnemiesOnWave.ContainsKey(enemy.Type))
         {
             currentEnemiesOnWave[enemy.Type]--;

--- a/Assets/Scripts/GameScripts/WaveSO.cs
+++ b/Assets/Scripts/GameScripts/WaveSO.cs
@@ -12,6 +12,10 @@ using UnityEngine;
 public class WaveSO : ScriptableObject
 {
     /// <summary>
+    /// It starts in Wave 1, and so on...
+    /// </summary>
+    public int WaveNumber;
+    /// <summary>
     /// Defines the max ammount of BLOB enemies on the wave
     /// 0 should spawn NO enemies of this type
     /// </summary>

--- a/Assets/Scripts/HealthSystem.cs
+++ b/Assets/Scripts/HealthSystem.cs
@@ -9,9 +9,8 @@ public class HealthSystem : MonoBehaviour
     [SerializeField] float maxHealth;
     [SerializeField] float currentShield;
     [SerializeField] float maxShield;
-
     [SerializeField] bool isInvulnerable;
-
+    [SerializeField] bool isPlayer;
     public float Health { get { return currentHealth; } }
     public bool IsInvulnerable { get { return isInvulnerable; } }
 
@@ -27,34 +26,46 @@ public class HealthSystem : MonoBehaviour
 
     private void OnDeath()
     {
+        if (isPlayer)
+        {
+            EventManager.TriggerOnPlayerDeath();
+        }
+        else
+        {
+            EventManager.TriggerOnEnemyDeath(gameObject);
+        }
+
         gameObject.SetActive(false);
     }
 
     private void UpdateUI()
     {
-        EventManager.UpdatePlayerLifeUI(currentHealth, maxHealth);
+        if(isPlayer)
+            EventManager.UpdatePlayerLifeUI(currentHealth, maxHealth);
     }
 
     public void TakeDamage(float dmg, TypeOfSpellElement elementType) // Valores Negativos Suman Vida
     {
         if (isInvulnerable) return;
-
-        UpdateUI();
-
         currentHealth = (currentHealth > 0) ? currentHealth - dmg : 0;
+        UpdateUI();
     }
 
     public void Revive(double healthPercent) // Ingrese Value 0.0 to 1.0
     {
         currentHealth = maxHealth * (float)healthPercent;
+        
         UpdateUI();
+        
         gameObject.SetActive(true);
     }
     public void Revive(Vector3 position, double healthPercent)
     {
         currentHealth = maxHealth * (float)healthPercent;
         transform.position = position;
+        
         UpdateUI();
+        
         gameObject.SetActive(true);
     }
     public void SwitchVulnerable(bool isInvulnerable) => this.isInvulnerable = isInvulnerable;

--- a/Assets/Scripts/Spells/Spell.cs
+++ b/Assets/Scripts/Spells/Spell.cs
@@ -8,7 +8,8 @@ public enum TypeOfSpellElement
     None,
     Fire,
     Thunder,
-    Ice
+    Ice,
+    Physical
 }
 
 public enum TypeOfSpells


### PR DESCRIPTION
-Primary Spell in left click, Secondary Spell in right click 
-Added all triggers for EventManager Events
-PlayerOnDeath, EnemyOnDeath, UpdateWaveUI, UpdateScoreUI event subscribers added and its triggers; IN classes with EVENTS PlaceHolders (WaveController, GameController, EnemySpawn, EnemyPool) 
-MISSING: Score updated on screen and wave info in UI. There UI methods need to subscribe to UpdateWaveUi and UpdateScoreUI -Added number of Wave in WaveSO (Because wave controller needs to pass that number to trigger UpdateWaveUI)
-Added type of spell Physical: So that we can re-use TakeDmg with player 
-Easy ugly fix: now health is only updated with player's healthsystem. Added isplayer variable to Healthsystem -Added player collision, take hit from enemies